### PR TITLE
Use `ft::swap` instead of `std::swap` for re-implementation tests

### DIFF
--- a/config.hpp
+++ b/config.hpp
@@ -5,11 +5,10 @@
 /*				or comment #include				  */
 /*		if you haven't yet some container		  */
 /**************************************************/
-#define VECTOR			"../../../Vector.hpp"
-#define STACK			"../../../Stack.hpp"
-#define MAP			  	"../../../Map.hpp"
-#define SET			  	"../../../Set.hpp"
-#define UTILITIES		"../../../Utility.hpp"
+#define VECTOR			"../../../vector.hpp"
+#define STACK			"../../../stack.hpp"
+// #define MAP			  	"../map.hpp"
+// #define UTILITIES		"../../../Utility.hpp"
 
 /* comment this to turn OFF flags (-WWW, -std=98) */
 // #define FLAGS
@@ -17,10 +16,9 @@
 /**************************************************/
 /*		Change template names of your classes	  */
 /**************************************************/
-#define	_vector 			ft::Vector
-#define	_stack	 			ft::Stack
-#define	_map 				ft::Map
-#define	_set	 			ft::Set
+#define	_vector 			ft::vector
+#define	_stack	 			ft::stack
+// #define	_map 				ft::map
 #define	_is_integral 		ft::is_integral
 #define	_enable_if 			ft::enable_if
 #define	_pair 				ft::pair

--- a/sources/map_tests/__service.ipp
+++ b/sources/map_tests/__service.ipp
@@ -74,7 +74,7 @@ int run_map_unit_test(std::string test_name, std::vector<int> (func1)(std::map<T
 	t1 = g_end1 - g_start1, t2 = g_end2 - g_start2;
 	(t1 >= t2) ? printElement(GREEN + std::to_string(t2) + "ms" + RESET) : printElement(REDD + std::to_string(t2) + "ms" + RESET);
 	(t1 > t2) ? printElement(REDD + std::to_string(t1) + "ms" + RESET) : printElement(GREEN + std::to_string(t1) + "ms" + RESET);
-	leaks = leaks_test(getpid());
+	// leaks = leaks_test(getpid());
 	cout << endl;
 
 	return !(!result && !leaks);

--- a/sources/map_tests/swap().cpp
+++ b/sources/map_tests/swap().cpp
@@ -50,7 +50,7 @@ std::vector<int> swap_test(_map<T, V> mp) {
         v.push_back(it->first);
         v.push_back(it->second);
     }
-    std::swap(mp, mp2);
+    ft::swap(mp, mp2);
     typename _map<T, V>::iterator it2 = mp2.begin();
     for (; it2 != mp2.end(); ++it2) {
         v.push_back(it2->first);

--- a/sources/set_tests/__service.ipp
+++ b/sources/set_tests/__service.ipp
@@ -74,7 +74,7 @@ int run_set_unit_test(std::string test_name, std::vector<int> (func1)(std::set<T
 	t1 = g_end1 - g_start1, t2 = g_end2 - g_start2;
 	(t1 >= t2) ? printElement(GREEN + std::to_string(t2) + "ms" + RESET) : printElement(REDD + std::to_string(t2) + "ms" + RESET);
 	(t1 > t2) ? printElement(REDD + std::to_string(t1) + "ms" + RESET) : printElement(GREEN + std::to_string(t1) + "ms" + RESET);
-	leaks = leaks_test(getpid());
+	// leaks = leaks_test(getpid());
 	cout << endl;
 
 	return !(!result && !leaks);

--- a/sources/set_tests/swap().cpp
+++ b/sources/set_tests/swap().cpp
@@ -47,7 +47,7 @@ std::vector<int> swap_test(_set<T> st) {
     for (; it != st2.end(); ++it) {
         v.push_back(*it);
     }
-    std::swap(st, st2);
+    ft::swap(st, st2);
     typename _set<T>::iterator it2 = st2.begin();
     for (; it2 != st2.end(); ++it2) {
         v.push_back(*it2);

--- a/sources/stack_tests/__service.ipp
+++ b/sources/stack_tests/__service.ipp
@@ -48,7 +48,7 @@ int run_stack_unit_test(std::string test_name, std::vector<int> (func1)(std::sta
 	t1 = g_end1 - g_start1, t2 = g_end2 - g_start2;
 	(t1 >= t2) ? printElement(GREEN + std::to_string(t2) + "ms" + RESET) : printElement(REDD + std::to_string(t2) + "ms" + RESET);
 	(t1 > t2) ? printElement(REDD + std::to_string(t1) + "ms" + RESET) : printElement(GREEN + std::to_string(t1) + "ms" + RESET);
-	leaks = leaks_test(getpid());
+	// leaks = leaks_test(getpid());
 	cout << endl;
 
 	return !(!result && !leaks);;

--- a/sources/vector_tests/__service.ipp
+++ b/sources/vector_tests/__service.ipp
@@ -27,7 +27,7 @@ int run_vector_unit_test(std::string test_name, std::vector<int> (func1)(std::ve
 	t1 = g_end1 - g_start1, t2 = g_end2 - g_start2;
 	(t1 >= t2) ? printElement(GREEN + std::to_string(t2) + "ms" + RESET) : printElement(REDD + std::to_string(t2) + "ms" + RESET);
 	(t1 > t2) ? printElement(REDD + std::to_string(t1) + "ms" + RESET) : printElement(GREEN + std::to_string(t1) + "ms" + RESET);
-	leaks = leaks_test(getpid());
+	// leaks = leaks_test(getpid());
 	cout << endl;
 
 	return !(!result && !leaks);

--- a/sources/vector_tests/swap().cpp
+++ b/sources/vector_tests/swap().cpp
@@ -55,11 +55,11 @@ std::vector<int> swap_test(_vector<T> vector) {
     v.push_back(vector[2]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
-    std::swap(vector, tmp2);
+    ft::swap(vector, tmp2);
     v.push_back(vector[2]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
-    std::swap(vector, tmp4);
+    ft::swap(vector, tmp4);
     g_end2 = timer();
     v.push_back(vector[2]);
     v.push_back(vector.size());


### PR DESCRIPTION
As explained [in this open issue](https://github.com/divinepet/ft_containers-unit-test/issues/7), some tests are not using `ft::swap`, making the tests fail.
I might be wrong, but I think there's no way of using `std::swap` with our own re-implementations.