### PR TITLE
Prevent from segfault in fast mode

### DIFF
--- a/sources/vector_tests/assign().cpp
+++ b/sources/vector_tests/assign().cpp
@@ -7,17 +7,17 @@ std::vector<int> assign_test(std::vector<T> vector) {
     std::vector<int> tmp, tmp2;
     vector.assign(3, 3);
     tmp.assign(4000 * _ratio, 1);
-    tmp2.assign(4 * _ratio, 1);
+    tmp2.assign(40 * _ratio, 1);
     g_start1 = timer();
     vector.assign(tmp.begin(), tmp.end());
     v.push_back(vector[1]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
     vector.assign(tmp2.begin(), tmp2.end());
-    g_end1 = timer();
-    v.push_back(vector[444]);
+    v.push_back(vector[4]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
+    g_end1 = timer();
     return v;
 }
 
@@ -27,17 +27,17 @@ std::vector<int> assign_test(_vector<T> vector) {
     _vector<int> tmp, tmp2;
     vector.assign(3, 3);
     tmp.assign(4000 * _ratio, 1);
-    tmp2.assign(4 * _ratio, 1);
+    tmp2.assign(40 * _ratio, 1);
     g_start2 = timer();
     vector.assign(tmp.begin(), tmp.end());
     v.push_back(vector[1]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
     vector.assign(tmp2.begin(), tmp2.end());
-    g_end2 = timer();
-    v.push_back(vector[444]);
+    v.push_back(vector[4]);
     v.push_back(vector.size());
     v.push_back(vector.capacity());
+    g_end2 = timer();
     return v;
 }
 


### PR DESCRIPTION
In fast mode, "vector[444]" causes a segfault. Timer is moved to the end of the function.